### PR TITLE
Display Bluetooth devices in Advanced tab

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj binary merge=union

--- a/LoRax/LoRax.xcodeproj/project.pbxproj
+++ b/LoRax/LoRax.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LoRax/Preview Content\"";
-				DEVELOPMENT_TEAM = 34NDP3BGK5;
+				DEVELOPMENT_TEAM = UJGA5JTS4G;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -438,7 +438,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.nmsu.LoRax;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.nmsu.Lorax;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -454,7 +454,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LoRax/Preview Content\"";
-				DEVELOPMENT_TEAM = 34NDP3BGK5;
+				DEVELOPMENT_TEAM = UJGA5JTS4G;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -467,7 +467,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.nmsu.LoRax;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.nmsu.Lorax;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/LoRax/LoRax.xcodeproj/project.pbxproj
+++ b/LoRax/LoRax.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.nmsu.Lorax;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.nmsu.LoRax;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -467,7 +467,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.nmsu.Lorax;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.nmsu.LoRax;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Using the CoreBluetooth framework, I was able to get some bluetooth functionality added to the app. This PR will place a button in the advanced tab that, once pressed, will display a list of Bluetooth devices. Unfortunately I can't test this quite yet without a USB-C to Lightning cable which I have ordered. @maxjtodd perhaps you can test in the mean time?